### PR TITLE
feat: override echo response status with query param or header

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -37,6 +37,11 @@ It starts a single http server to handle
 
 This HTTP endpoint can receive HTTP request. It will copy the request received in a 200 response.
 
+You can override the response status code by setting
+
+- the query parameter `statusCode`.
+- or the header `X-Override-Status-Code`.
+
 ==== Example
 
 Using https://httpie.io/cli[httpie]:


### PR DESCRIPTION
Setting the `statusCode` query param or `X-Override-Status-Code` header will change the response status code of Echo resource with the value provided. When the value is not a number it fallback on 200.